### PR TITLE
Add spacing to magnet sheet PDF

### DIFF
--- a/magnetlayout.html
+++ b/magnetlayout.html
@@ -152,8 +152,8 @@
 
       for (let row = 0; row < magnetsPerCol; row++) {
         for (let col = 0; col < magnetsPerRow; col++) {
-          const x = marginLeft + col * magnetInches;
-          const y = marginTop + row * magnetInches;
+          const x = marginLeft + col * totalSize;
+          const y = marginTop + row * totalSize;
           doc.addImage(imgData, "PNG", x, y, magnetInches, magnetInches);
         }
       }


### PR DESCRIPTION
Add white space between images in the generated PDF by correctly applying the defined gap.

---
<a href="https://cursor.com/background-agent?bcId=bc-c88208bc-e9bc-45e0-a1c9-3e843e69b82d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c88208bc-e9bc-45e0-a1c9-3e843e69b82d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>